### PR TITLE
feat: wait load js for lms

### DIFF
--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -1,5 +1,5 @@
 /* Javascript for StaffGradedAssignmentXBlock. */
-function StaffGradedAssignmentXBlock(runtime, element) {
+async function StaffGradedAssignmentXBlock(runtime, element) {
   function xblock($, _) {
     var uploadUrl = runtime.handlerUrl(element, 'upload_assignment');
     var finalizeUploadUrl = runtime.handlerUrl(element, 'finalize_uploaded_assignment');
@@ -409,7 +409,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
 
 
     function sendResizeMessage(height) {
-      // This blocks checks to see if the xBlock is part 
+      // This blocks checks to see if the xBlock is part
       // of Learning MFE
       if (window.parent !== window) {
         window.parent.postMessage({
@@ -474,13 +474,30 @@ function StaffGradedAssignmentXBlock(runtime, element) {
     return deferred.promise();
   }
 
-  function loadjs(url) {
-    $('<script>')
-      .attr('type', 'text/javascript')
-      .attr('src', window.baseUrl + url)
-      .appendTo(element);
-  }
+  function loadjs(src) {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true; // Essential for non-blocking loading
 
+      // Resolve the promise when the script is successfully loaded
+      script.onload = () => {
+        console.log(`Script loaded: ${src}`);
+        resolve(script);
+      };
+
+      // Reject the promise if there's an error loading the script
+      script.onerror = () => {
+        const errorMsg = `Failed to load script: ${src}`;
+        console.error(errorMsg);
+        reject(new Error(errorMsg));
+      };
+
+      // Append the script to the document body or head
+      // Appending to head is often preferred for libraries
+      document.head.appendChild(script);
+    });
+  }
   if (require === undefined) {
     /**
      * The LMS does not use require.js (although it loads it...) and
@@ -488,8 +505,12 @@ function StaffGradedAssignmentXBlock(runtime, element) {
      * jquery.ajaxfileupload instead.  But our XBlock uses
      * jquery.fileupload.
      */
-    loadjs('js/vendor/jQuery-File-Upload/js/jquery.iframe-transport.js');
-    loadjs('js/vendor/jQuery-File-Upload/js/jquery.fileupload.js');
+    baseUrl = window.baseUrl || '';
+    // Refactored code to wait for both jQuery File Upload dependencies
+    await Promise.all([
+      loadjs(baseUrl + 'js/vendor/jQuery-File-Upload/js/jquery.iframe-transport.js'),
+      loadjs(baseUrl + 'js/vendor/jQuery-File-Upload/js/jquery.fileupload.js'),
+    ]);
     xblock($, _);
   } else {
     /**

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -493,9 +493,8 @@ async function StaffGradedAssignmentXBlock(runtime, element) {
         reject(new Error(errorMsg));
       };
 
-      // Append the script to the document body or head
-      // Appending to head is often preferred for libraries
-      document.head.appendChild(script);
+      // Append the script to the element
+      element.appendChild(script);
     });
   }
   if (require === undefined) {

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -1,5 +1,5 @@
 /* Javascript for StaffGradedAssignmentXBlock. */
-async function StaffGradedAssignmentXBlock(runtime, element) {
+function StaffGradedAssignmentXBlock(runtime, element) {
   function xblock($, _) {
     var uploadUrl = runtime.handlerUrl(element, 'upload_assignment');
     var finalizeUploadUrl = runtime.handlerUrl(element, 'finalize_uploaded_assignment');
@@ -506,11 +506,15 @@ async function StaffGradedAssignmentXBlock(runtime, element) {
      */
     baseUrl = window.baseUrl || '';
     // Refactored code to wait for both jQuery File Upload dependencies
-    await Promise.all([
+    Promise.all([
       loadjs(baseUrl + 'js/vendor/jQuery-File-Upload/js/jquery.iframe-transport.js'),
       loadjs(baseUrl + 'js/vendor/jQuery-File-Upload/js/jquery.fileupload.js'),
-    ]);
-    xblock($, _);
+    ]).then(() => {
+      xblock($, _);
+    }).catch((error) => {
+      // Handle any errors during loading
+      console.error("Error loading scripts:", error);
+    });
   } else {
     /**
      * Studio, on the other hand, uses require.js and already knows about


### PR DESCRIPTION
#### What's this PR do?
Fix cloudfront compatibility with missing js files loads.

This ensure to load the extra js files before xblock is called.

## Before 
![2025-07-04_10-58](https://github.com/user-attachments/assets/631e2caf-4cb0-4e33-8588-2be8f56e353b)

**Stage**:

![2025-07-04_20-44](https://github.com/user-attachments/assets/5ec3a821-b2da-43c5-a3d0-436bd9160559)


## After

![image](https://github.com/user-attachments/assets/4b18a43d-d3b2-4261-bf4f-9770b2e8eafd)



**Stage**:

![image](https://github.com/user-attachments/assets/147acf32-5692-481e-b262-205666f883e3)

#### Jira story 

https://edunext.atlassian.net/browse/FUTUREX-1215