### PR TITLE
fix: cherry-pick fix tests backport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.12']
+        edx_branch: ['master', 'open-release/redwood.master', 'open-release/sumac.master']
         toxenv: [py312-django32, py312-django42]
 
     steps:
@@ -26,8 +27,8 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}  
-      
+          python-version: ${{ matrix.python-version }}
+
       - name: tox install
         run: pip install tox
 
@@ -35,7 +36,7 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
         run: tox
-        
+
       - name: Upload coverage to CodeCov
         if: matrix.python-version == '3.12' && matrix.toxenv == 'py312-django42'
         uses: codecov/codecov-action@v3
@@ -43,14 +44,37 @@ jobs:
           file: ./coverage.xml
           fail_ci_if_error: false
 
-      - name: Run Integration Tests 
+      - name: Install tutor
         run: |
-            cd ..
-            git clone https://github.com/openedx/devstack
-            cd devstack
-            sed -i 's/:cached//g' ./docker-compose-host.yml
-            make dev.clone.https
-            DEVSTACK_WORKSPACE=$PWD/.. docker compose -f docker-compose.yml -f docker-compose-host.yml run -v $PWD/../edx-sga:/edx-sga lms /edx-sga/run_devstack_integration_tests.sh
+          if [[ "${{ matrix.edx_branch }}" == "open-release/redwood.master" ]]; then
+            pip install tutor==18.2.2
+          elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
+            git clone --branch=main https://github.com/overhangio/tutor.git
+            pip install -e "./tutor"
+          else
+            pip install tutor==19.0.0
+          fi
+
+      - name: Set up tutor with edx-platform
+        run: |
+          cd ..
+          git clone https://github.com/openedx/edx-platform
+          cd edx-platform
+          git checkout ${{ matrix.edx_branch }}
+          tutor mounts add .
+          tutor dev launch --non-interactive
+          tutor dev stop
+
+      - name: Run Integration Tests
+        run: |
+          if [[ "${{ matrix.edx_branch }}" == "master" ]]; then
+            DIRECTORY="tutor-main"
+            DEV="tutor_main_dev"
+          else
+            DIRECTORY="tutor"
+            DEV="tutor_dev"
+          fi
+          EDX_WORKSPACE=$PWD/.. docker compose -f /home/runner/.local/share/$DIRECTORY/env/local/docker-compose.yml -f /home/runner/.local/share/$DIRECTORY/env/dev/docker-compose.yml --project-name $DEV run -v $PWD/../edx-sga:/edx-sga lms /edx-sga/run_edx_integration_tests.sh
 
       - name: Upload coverage to CodeCov
         if: matrix.python-version == '3.12' && matrix.toxenv == 'py312-django42'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             cd devstack
             sed -i 's/:cached//g' ./docker-compose-host.yml
             make dev.clone.https
-            DEVSTACK_WORKSPACE=$PWD/.. docker-compose -f docker-compose.yml -f docker-compose-host.yml run -v $PWD/../edx-sga:/edx-sga lms /edx-sga/run_devstack_integration_tests.sh
+            DEVSTACK_WORKSPACE=$PWD/.. docker compose -f docker-compose.yml -f docker-compose-host.yml run -v $PWD/../edx-sga:/edx-sga lms /edx-sga/run_devstack_integration_tests.sh
 
       - name: Upload coverage to CodeCov
         if: matrix.python-version == '3.12' && matrix.toxenv == 'py312-django42'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.12']
         edx_branch: ['master', 'open-release/redwood.master', 'open-release/sumac.master']
         toxenv: [py312-django32, py312-django42]

--- a/run_edx_integration_tests.sh
+++ b/run_edx_integration_tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-source /edx/app/edxapp/venvs/edxapp/bin/activate
+source /openedx/venv/bin/activate
 
-cd /edx/app/edxapp/edx-platform
+cd /openedx/edx-platform
 mkdir -p reports
 
 pip install -r requirements/edx/testing.txt
@@ -18,9 +18,9 @@ pip install -e .
 pip freeze
 
 # adjust test files for integration tests
-cp /edx/app/edxapp/edx-platform/setup.cfg .
+cp /openedx/edx-platform/setup.cfg .
 rm ./pytest.ini
 mkdir test_root  # for edx
 
-pytest ./edx_sga/tests/integration_tests.py --cov .
+pytest ./edx_sga/tests/integration_tests.py --cov . --ds=lms.envs.test
 coverage xml

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,7 +11,7 @@ edx-opaque-keys
 edx-submissions==3.6.0
 jsonfield==3.1.0
 mako==1.2.4
-pdbpp==0.10.3
+pdbpp==0.11.6
 pylint==3.0.3
 pylint-celery==0.3
 pylint-django==2.5.5


### PR DESCRIPTION
# Descripton

Multiple cherry-pick to fix tests.

Ubuntu 20.04 is deprecated in favor of more recent versions

(cherry picked from commit 4d09e28d7694909c0f75ffed4208d1c8fc5ddcd0)

